### PR TITLE
refactor(memo-editor): 移除全屏功能并优化编辑器焦点体验

### DIFF
--- a/src/components/ui/expandable-content.tsx
+++ b/src/components/ui/expandable-content.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useState, useRef, useEffect, ReactNode } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { ArrowDown01Icon, ArrowUp01Icon } from '@hugeicons/core-free-icons';
+
+interface ExpandableContentProps {
+    children: ReactNode;
+    needsExpansion: boolean;
+    collapsedHeight?: number;
+}
+
+export function ExpandableContent({ 
+    children, 
+    needsExpansion, 
+    collapsedHeight = 160 
+}: ExpandableContentProps) {
+    const [isExpanded, setIsExpanded] = useState(false);
+    // 默认假定需要折叠，避免加载闪烁；ResizeObserver 会快速纠正它
+    const [isActuallyExpandable, setIsActuallyExpandable] = useState(true);
+    const contentRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        if (!needsExpansion) {
+            return;
+        }
+
+        const resizeObserver = new ResizeObserver((entries) => {
+            for (const entry of entries) {
+                // 判断实际内容高度：如果超出预设高度一定阈值（比如 40px），才真正判定为可折叠
+                const scrollHeight = entry.target.scrollHeight;
+                setIsActuallyExpandable(scrollHeight > collapsedHeight + 40);
+            }
+        });
+
+        if (contentRef.current) {
+            resizeObserver.observe(contentRef.current);
+        }
+
+        return () => resizeObserver.disconnect();
+    }, [needsExpansion, collapsedHeight]);
+
+    const finalExpandable = needsExpansion && isActuallyExpandable;
+
+    // 如果字数或行数条件根本没达到，直接渲染原内容
+    if (!needsExpansion) return <>{children}</>;
+
+    return (
+        <div className="relative group/expandable w-full">
+            <motion.div 
+                layout
+                initial={false}
+                // 如果实际不需要折叠（高度不够），就不限制高度
+                animate={{ height: (isExpanded || !finalExpandable) ? 'auto' : collapsedHeight }}
+                className="overflow-hidden relative will-change-auto"
+                transition={{ duration: 0.35, ease: [0.33, 1, 0.68, 1] }}
+            >
+                <div ref={contentRef}>
+                    {children}
+                </div>
+                
+                <AnimatePresence>
+                    {!isExpanded && finalExpandable && (
+                        <motion.div 
+                            initial={{ opacity: 0 }} 
+                            animate={{ opacity: 1 }} 
+                            exit={{ opacity: 0 }}
+                            className="absolute bottom-0 left-0 right-0 h-16 bg-gradient-to-t from-card to-transparent pointer-events-none z-10" 
+                        />
+                    )}
+                </AnimatePresence>
+            </motion.div>
+
+            <AnimatePresence>
+                {finalExpandable && (
+                    <motion.div 
+                        initial={{ opacity: 0, y: -10 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        exit={{ opacity: 0, y: -10 }}
+                        className={`flex justify-center relative z-20 transition-all duration-300 ${isExpanded ? 'mt-2 mb-1' : '-mt-3'}`}
+                    >
+                        <button
+                            onClick={(e) => {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                setIsExpanded(!isExpanded);
+                            }}
+                            className="flex items-center gap-1.5 px-3 py-1 bg-muted/80 backdrop-blur text-muted-foreground text-[10px] font-medium rounded-full hover:bg-primary hover:text-primary-foreground transition-all cursor-pointer shadow-sm border border-border/50"
+                        >
+                            {isExpanded ? '收起内容' : '展开内容'}
+                            <HugeiconsIcon icon={isExpanded ? ArrowUp01Icon : ArrowDown01Icon} size={12} />
+                        </button>
+                    </motion.div>
+                )}
+            </AnimatePresence>
+        </div>
+    );
+}

--- a/src/features/memos/components/MemoActions.tsx
+++ b/src/features/memos/components/MemoActions.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { deleteMemo, restoreMemo, permanentDeleteMemo } from '@/actions/memos/trash';
 import { updateMemoState } from '@/actions/memos/mutate';
+import { dispatchMemoEvent } from '@/lib/memos/events';
 import { memoCache } from '@/lib/memo-cache';
 import { HugeiconsIcon } from '@hugeicons/react';
 import { Delete02Icon, RotateLeft01Icon, MoreHorizontalIcon, PencilEdit01Icon, Share01Icon, PinIcon, ChatLock01Icon, ChatUnlock01Icon } from '@hugeicons/core-free-icons';
@@ -72,7 +73,7 @@ export function MemoActions({
         await deleteMemo(id);
         memoCache.removeItem(id);
         setIsPending(false);
-        window.dispatchEvent(new CustomEvent('memo-deleted', { detail: { id } }));
+        dispatchMemoEvent({ type: 'delete', id });
         toast({
             title: "已删除",
             description: "记录已移至回收站",
@@ -83,7 +84,7 @@ export function MemoActions({
         setIsPending(true);
         await restoreMemo(id);
         setIsPending(false);
-        window.dispatchEvent(new CustomEvent('memo-deleted', { detail: { id } }));
+        dispatchMemoEvent({ type: 'delete', id });
         toast({
             title: "已恢复",
             description: "记录已恢复至首页",
@@ -94,7 +95,7 @@ export function MemoActions({
         setIsPending(true);
         await permanentDeleteMemo(id);
         setIsPending(false);
-        window.dispatchEvent(new CustomEvent('memo-deleted', { detail: { id } }));
+        dispatchMemoEvent({ type: 'delete', id });
         toast({
             title: "彻底销毁",
             description: "该记录已从数据库物理删除",
@@ -109,7 +110,7 @@ export function MemoActions({
         formData.append('is_pinned', String(!isPinned));
         await updateMemoState(formData);
         setIsPending(false);
-        window.dispatchEvent(new CustomEvent('memo-updated', { detail: { id, updates: { is_pinned: !isPinned } } }));
+        dispatchMemoEvent({ type: 'update', id, updates: { is_pinned: !isPinned } });
         toast({
             title: !isPinned ? "已置顶" : "已取消置顶",
         });
@@ -124,7 +125,7 @@ export function MemoActions({
         if (result?.error) {
             toast({ title: "错误", description: result.error, variant: "destructive" });
         } else {
-            window.dispatchEvent(new CustomEvent('memo-updated', { detail: { id, updates: { is_private: false } } }));
+            dispatchMemoEvent({ type: 'update', id, updates: { is_private: false } });
             toast({ title: "已公开", description: "该记录现在所有人可见" });
         }
         setIsPending(false);
@@ -154,7 +155,7 @@ export function MemoActions({
         if (result?.error) {
             toast({ title: "错误", description: result.error, variant: "destructive" });
         } else {
-            window.dispatchEvent(new CustomEvent('memo-updated', { detail: { id, updates: { is_private: true } } }));
+            dispatchMemoEvent({ type: 'update', id, updates: { is_private: true } });
             toast({ title: "已设为私密", description: code ? "已启用口令保护" : "已设为仅自己可见" });
         }
         setIsPending(false);

--- a/src/features/memos/components/MemoEditor.tsx
+++ b/src/features/memos/components/MemoEditor.tsx
@@ -2,16 +2,11 @@
 
 import { useRef, useEffect, useMemo } from 'react';
 import { HugeiconsIcon } from '@hugeicons/react';
-import { Minimize01Icon as Minimize2 } from '@hugeicons/core-free-icons';
 import { cn } from '@/lib/utils';
 import { EditorContent, useEditor } from '@tiptap/react';
 import { motion } from 'framer-motion';
 
-import {
-    Dialog,
-    DialogContent,
-    DialogTitle,
-} from "@/components/ui/dialog";
+
 import { spring, ease, duration } from '@/lib/animation';
 
 import { EditorSuggestionMenu } from '@/features/memos/components/EditorSuggestionMenu';
@@ -30,7 +25,6 @@ interface MemoEditorProps {
     onCancel?: () => void;
     onSuccess?: (memo?: Memo) => void;
     isCollapsed?: boolean;
-    hideFullscreen?: boolean;
     className?: string;
 }
 
@@ -40,7 +34,6 @@ export function MemoEditor({
     onCancel,
     onSuccess,
     isCollapsed: isPropCollapsed = false,
-    hideFullscreen = false,
     className,
 }: MemoEditorProps) {
     const editorContainerRef = useRef<HTMLDivElement>(null);
@@ -56,7 +49,6 @@ export function MemoEditor({
         error, setError,
         showPrivateDialog, setShowPrivateDialog,
         isFocused, setIsFocused,
-        isFullscreen, setIsFullscreen,
         isAnimating, setIsAnimating,
         showLocationPicker, setShowLocationPicker,
         handleTogglePrivate,
@@ -82,7 +74,7 @@ export function MemoEditor({
         handleSuggestionScroll
     } = useEditorSuggestions();
 
-    const isActuallyCollapsed = isPropCollapsed && !isFocused && mode === 'create';
+    const isActuallyCollapsed = isPropCollapsed && !isFocused && !showLocationPicker && !showPrivateDialog && mode === 'create';
 
     const extensions = useMemo(() => 
         // eslint-disable-next-line react-hooks/refs
@@ -255,8 +247,7 @@ export function MemoEditor({
             attributes: {
                 class: cn(
                     "tiptap prose prose-sm max-w-none focus:outline-none text-foreground/80 leading-relaxed tracking-normal",
-                    hideFullscreen ? "flex-1 min-h-full px-1 focus:outline-none" : "min-h-[120px]",
-                    "text-base"
+                    "min-h-[120px] text-base"
                 ),
             },
         },
@@ -281,28 +272,15 @@ export function MemoEditor({
         }
     }, [editor, memo, mode, setContent]);
 
-    // Fullscreen Sync Effect
-    useEffect(() => {
-        if (!hideFullscreen && !isFullscreen && mode === 'create' && editor) {
-            const draftContent = localStorage.getItem(DRAFT_CONTENT_KEY);
-            if (draftContent !== null) {
-                try {
-                    editor.commands.setContent(JSON.parse(draftContent));
-                } catch {
-                    editor.commands.setContent(draftContent);
-                }
-                setContent(editor.getText());
-            }
-        }
-    }, [isFullscreen, hideFullscreen, mode, editor, setContent]);
+
 
     return (
         <motion.section
             initial={false}
             animate={{
                 opacity: 1,
-                height: isActuallyCollapsed ? "auto" : (hideFullscreen ? "100%" : "auto"),
-                minHeight: isActuallyCollapsed ? 0 : (hideFullscreen ? "100%" : 120),
+                height: isActuallyCollapsed ? "auto" : "auto",
+                minHeight: isActuallyCollapsed ? 0 : 120,
                 padding: 24,
                 boxShadow: isActuallyCollapsed ? "none" : "0 1px 2px 0 rgb(0 0 0 / 0.05)",
             }}
@@ -323,11 +301,11 @@ export function MemoEditor({
             }}
             className={cn(
                 "border border-border rounded-inner relative flex flex-col items-stretch selection:bg-primary/30",
-                isActuallyCollapsed ? "shadow-none cursor-pointer hover:bg-accent/5" : (hideFullscreen ? "h-full" : ""),
+                isActuallyCollapsed && "shadow-none cursor-pointer hover:bg-accent/5",
                 className
             )}
             onClick={() => {
-                if ((isActuallyCollapsed || hideFullscreen) && editor) {
+                if (isActuallyCollapsed && editor) {
                     const selection = window.getSelection();
                     if (!selection || selection.toString().length === 0) {
                         editor.commands.focus('end');
@@ -345,15 +323,15 @@ export function MemoEditor({
                     <motion.div
                         ref={editorContainerRef}
                         animate={{
-                            height: isActuallyCollapsed ? 26 : (hideFullscreen ? "100%" : "auto"),
-                            minHeight: isActuallyCollapsed ? 0 : (hideFullscreen ? "100%" : 120),
+                            height: isActuallyCollapsed ? 26 : "auto",
+                            minHeight: isActuallyCollapsed ? 0 : 120,
                         }}
                         className={cn(
                             "relative",
-                            isActuallyCollapsed ? "min-h-0 scrollbar-hide overflow-hidden" : (hideFullscreen ? "overflow-y-auto scrollbar-hover flex-1" : "overflow-visible")
+                            isActuallyCollapsed ? "min-h-0 scrollbar-hide overflow-hidden" : "overflow-y-auto scrollbar-hover"
                         )}
                         style={{
-                            maxHeight: hideFullscreen ? 'none' : 500,
+                            maxHeight: 500,
                             maskImage: isActuallyCollapsed ? 'linear-gradient(to bottom, black 90%, transparent 100%)' : 'none',
                         }}
                     >
@@ -362,7 +340,7 @@ export function MemoEditor({
                                 <p>Wanna memo something? JustMemo it!</p>
                             </div>
                         )}
-                        <EditorContent editor={editor} className={cn("flex-1 flex flex-col min-h-0", hideFullscreen && "h-full")} />
+                        <EditorContent editor={editor} className="flex-1 flex flex-col min-h-0" />
                     </motion.div>
 
                     {showSuggestions && (
@@ -390,42 +368,23 @@ export function MemoEditor({
                     isPrivate={isPrivate}
                     isPinned={isPinned}
                     isPending={isPending}
-                    isFullscreenAvailable={!hideFullscreen}
                     content={content}
                     mode={mode}
                     onTogglePrivate={handleTogglePrivate}
                     onTogglePinned={() => setIsPinned(!isPinned)}
                     onShowLocationPicker={() => setShowLocationPicker(true)}
-                    onShowFullscreen={() => setIsFullscreen(true)}
                     onCancel={handleCancel}
                     onPublish={() => isPrivate ? setShowPrivateDialog(true) : performPublish(editor)}
                 />
             </div>
 
-            <Dialog open={isFullscreen} onOpenChange={setIsFullscreen}>
-                <DialogContent
-                    className="max-w-5xl h-[92vh] flex flex-col p-0 gap-0 overflow-hidden bg-background"
-                    closeIcon={<HugeiconsIcon icon={Minimize2} size={16} />}
-                >
-                    <DialogTitle className="sr-only">全屏编辑内容</DialogTitle>
-                    <div className="flex-1 overflow-visible flex items-stretch justify-center px-6 py-10 bg-black/5">
-                        <div className="max-w-4xl w-full mx-auto flex flex-col h-full [min-height:0]">
-                            <MemoEditor
-                                mode={mode}
-                                memo={memo}
-                                isCollapsed={false}
-                                hideFullscreen={true}
-                                onCancel={() => setIsFullscreen(false)}
-                                onSuccess={() => setIsFullscreen(false)}
-                            />
-                        </div>
-                    </div>
-                </DialogContent>
-            </Dialog>
 
             <MemoPrivateDialog
                 open={showPrivateDialog}
-                onOpenChange={setShowPrivateDialog}
+                onOpenChange={(open) => {
+                    setShowPrivateDialog(open);
+                    if (!open) { setIsFocused(true); editor?.commands.focus(); }
+                }}
                 accessCode={accessCode}
                 setAccessCode={setAccessCode}
                 accessHint={accessHint}
@@ -435,7 +394,10 @@ export function MemoEditor({
 
             <LocationPickerDialog
                 open={showLocationPicker}
-                onOpenChange={setShowLocationPicker}
+                onOpenChange={(open) => {
+                    setShowLocationPicker(open);
+                    if (!open) { setIsFocused(true); editor?.commands.focus(); }
+                }}
                 onConfirm={(loc) => editor?.chain().focus().insertContent(loc + ' ').run()}
             />
         </motion.section>

--- a/src/features/memos/components/editor/EditorToolbar.tsx
+++ b/src/features/memos/components/editor/EditorToolbar.tsx
@@ -6,7 +6,6 @@ import {
     PinIcon as Pin,
     LockIcon as Lock,
     CircleUnlock01Icon as LockOpen,
-    Maximize01Icon as Maximize2,
     Location04Icon,
 } from '@hugeicons/core-free-icons';
 import { cn } from '@/lib/utils';
@@ -18,13 +17,11 @@ interface EditorToolbarProps {
     isPrivate: boolean;
     isPinned: boolean;
     isPending: boolean;
-    isFullscreenAvailable: boolean;
     content: string;
     mode: 'create' | 'edit';
     onTogglePrivate: () => void;
     onTogglePinned: () => void;
     onShowLocationPicker: () => void;
-    onShowFullscreen: () => void;
     onCancel: () => void;
     onPublish: () => void;
 }
@@ -34,13 +31,11 @@ export function EditorToolbar({
     isPrivate,
     isPinned,
     isPending,
-    isFullscreenAvailable,
     content,
     mode,
     onTogglePrivate,
     onTogglePinned,
     onShowLocationPicker,
-    onShowFullscreen,
     onCancel,
     onPublish
 }: EditorToolbarProps) {
@@ -92,18 +87,7 @@ export function EditorToolbar({
                         <span className="text-xs font-medium">定位</span>
                     </Button>
 
-                    {isFullscreenAvailable && (
-                        <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={onShowFullscreen}
-                            className="h-8 px-2 gap-1.5 text-muted-foreground active:scale-95 transition-all hover:text-foreground"
-                            aria-label="放大"
-                        >
-                            <HugeiconsIcon icon={Maximize2} size={16} />
-                            <span className="text-xs font-medium">放大</span>
-                        </Button>
-                    )}
+
                 </div>
 
                 <div className="flex items-center gap-3">

--- a/src/features/memos/components/memo-card/MemoCardView.tsx
+++ b/src/features/memos/components/memo-card/MemoCardView.tsx
@@ -10,6 +10,7 @@ import { MemoCardHeader } from './MemoCardHeader';
 import { MemoCardBacklinks } from './MemoCardBacklinks';
 import { MemoCardLockOverlay } from './MemoCardLockOverlay';
 import { useMemoBacklinks } from '../../hooks/useMemoBacklinks';
+import { ExpandableContent } from '@/components/ui/expandable-content';
 
 interface MemoCardViewProps {
     memo: Memo;
@@ -71,16 +72,21 @@ export function MemoCardView({
                 hasMounted={hasMounted}
             />
 
-            <div className={cn("w-full transition-all", memo.is_locked && "blur-sm select-none")}>
+            <div className={cn("w-full transition-all mt-2", memo.is_locked && "blur-sm select-none")}>
                 {memo.is_locked ? (
                     <div className="text-base leading-relaxed text-muted-foreground italic opacity-60">
                         这一条私密记录已被锁定，输入口令后即可解锁阅读。
                     </div>
                 ) : (
-                    <MemoContent
-                        content={memo.content}
-                        disablePreview={showOriginalOnly}
-                    />
+                    <ExpandableContent
+                        needsExpansion={!showOriginalOnly && (memo.content.length > 300 || memo.content.split('\n').length > 8)}
+                        collapsedHeight={200}
+                    >
+                        <MemoContent
+                            content={memo.content}
+                            disablePreview={showOriginalOnly}
+                        />
+                    </ExpandableContent>
                 )}
             </div>
 

--- a/src/features/memos/hooks/useMemoEditor.ts
+++ b/src/features/memos/hooks/useMemoEditor.ts
@@ -35,7 +35,6 @@ export function useMemoEditor({ mode, initialMemo, onSuccess, onCancel }: UseMem
     // UI States that should stay in Hook for consistency
     const [showPrivateDialog, setShowPrivateDialog] = useState(false);
     const [isFocused, setIsFocused] = useState(false);
-    const [isFullscreen, setIsFullscreen] = useState(false);
     const [isAnimating, setIsAnimating] = useState(false);
     const [showLocationPicker, setShowLocationPicker] = useState(false);
 
@@ -152,7 +151,6 @@ export function useMemoEditor({ mode, initialMemo, onSuccess, onCancel }: UseMem
         error, setError,
         showPrivateDialog, setShowPrivateDialog,
         isFocused, setIsFocused,
-        isFullscreen, setIsFullscreen,
         isAnimating, setIsAnimating,
         showLocationPicker, setShowLocationPicker,
         handleTogglePrivate,

--- a/src/features/memos/hooks/useMemoEditor.ts
+++ b/src/features/memos/hooks/useMemoEditor.ts
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Memo } from '@/types/memo';
 import { createMemo, updateMemoContent } from '@/actions/memos/mutate';
+import { dispatchMemoEvent } from '@/lib/memos/events';
 import { memoCache } from '@/lib/memo-cache';
 import { useTags } from '@/context/TagsContext';
 import { useStats } from '@/context/StatsContext';
@@ -113,6 +114,10 @@ export function useMemoEditor({ mode, initialMemo, onSuccess, onCancel }: UseMem
                     setAccessCode('');
                     setAccessHint('');
                     setIsPinned(false);
+                    
+                    if (newMemo) {
+                        dispatchMemoEvent({ type: 'create', memo: newMemo });
+                    }
                 } else {
                     onSuccess?.(newMemo);
                 }

--- a/src/features/memos/hooks/useMemoFeed.ts
+++ b/src/features/memos/hooks/useMemoFeed.ts
@@ -1,9 +1,10 @@
 'use client';
 
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback } from 'react';
 import { Memo } from '@/types/memo';
 import { getMemos } from '@/actions/memos/query';
 import { mergeMemos } from '@/lib/streamUtils';
+import { useMemoSync, MemoEventPayload } from '@/lib/memos/events';
 
 interface UseMemoFeedProps {
     initialMemos: Memo[];
@@ -72,29 +73,22 @@ export function useMemoFeed({ initialMemos, searchParams, adminCode }: UseMemoFe
         setMemos(prev => prev.map(m => m.id === updatedMemo.id ? updatedMemo : m));
     }, []);
 
-    useEffect(() => {
-        const handleDeleted = (e: Event) => {
-            const detail = (e as CustomEvent).detail;
-            if (detail && detail.id) {
-                setMemos(prev => prev.filter(m => m.id !== detail.id));
+    useMemoSync(useCallback((payload: MemoEventPayload) => {
+        setMemos(prev => {
+            switch (payload.type) {
+                case 'create':
+                    // Prevent duplicates if already exists
+                    if (prev.some(m => m.id === payload.memo.id)) return prev;
+                    return mergeMemos(prev, [payload.memo]);
+                case 'update':
+                    return prev.map(m => m.id === payload.id ? { ...m, ...payload.updates } : m);
+                case 'delete':
+                    return prev.filter(m => m.id !== payload.id);
+                default:
+                    return prev;
             }
-        };
-        
-        const handleUpdated = (e: Event) => {
-            const detail = (e as CustomEvent).detail;
-            if (detail && detail.id && detail.updates) {
-                setMemos(prev => prev.map(m => m.id === detail.id ? { ...m, ...detail.updates } : m));
-            }
-        };
-        
-        window.addEventListener('memo-deleted', handleDeleted);
-        window.addEventListener('memo-updated', handleUpdated);
-        
-        return () => {
-            window.removeEventListener('memo-deleted', handleDeleted);
-            window.removeEventListener('memo-updated', handleUpdated);
-        };
-    }, []);
+        });
+    }, []));
 
     return {
         memos,

--- a/src/features/trash/components/TrashHeader.tsx
+++ b/src/features/trash/components/TrashHeader.tsx
@@ -26,36 +26,26 @@ export function TrashHeader({ count, isPending, onEmptyTrash }: TrashHeaderProps
         <header className="mb-12 flex flex-col md:flex-row md:items-end justify-between border-b border-border/10 pb-10">
             <div className="space-y-4">
                 <div className="flex items-center gap-4">
-                    <div className="relative flex items-center justify-center">
-                        <div className="absolute inset-0 bg-primary/5 rounded-full blur-xl animate-pulse" />
-                        <div className="relative w-12 h-12 flex items-center justify-center border border-primary/10 rounded-full bg-background/50 backdrop-blur-sm">
-                            <HugeiconsIcon icon={Archive} size={22} className="text-primary/60" />
-                        </div>
+                    <div className="w-12 h-12 flex items-center justify-center border border-border/20 rounded-xl bg-muted/30">
+                        <HugeiconsIcon icon={Archive} size={22} className="text-muted-foreground" />
                     </div>
                     <div>
-                        <h2 className="text-4xl font-bold tracking-tight italic text-foreground/90 selection:bg-primary/20">
+                        <h2 className="text-3xl font-semibold tracking-tight text-foreground/90">
                             回收站
                         </h2>
-                        <div className="flex items-center gap-2 mt-1">
-                            <div className="h-px w-8 bg-primary/20" />
-                            <span className="text-[10px] uppercase font-mono tracking-[0.3em] text-muted-foreground/50">
-                                Ethereal Archive
-                            </span>
-                        </div>
                     </div>
                 </div>
-                <p className="text-muted-foreground/60 text-xs font-sans tracking-wide leading-relaxed italic max-w-sm">
-                    Fragments intended for oblivion. 
+                <p className="text-muted-foreground/60 text-sm max-w-sm">
                     被遗忘的片段，在这里等待最后的归宿。
                 </p>
             </div>
             <div className="flex flex-col items-end gap-5 mt-6 md:mt-0">
                 <div className="flex flex-col items-end">
-                    <span className="text-[9px] font-mono text-muted-foreground/30 uppercase tracking-[0.4em] mb-1">
-                        Record Sequence
+                    <span className="text-[10px] font-mono text-muted-foreground/40 uppercase tracking-widest mb-1">
+                        RECORD SEQUENCE
                     </span>
-                    <div className="text-2xl font-mono text-foreground/60 tracking-tighter">
-                        <span className="opacity-20">NO.</span>{count.toString().padStart(4, '0')}
+                    <div className="text-2xl font-mono text-foreground/70 tracking-tighter">
+                        {count.toString().padStart(4, '0')}
                     </div>
                 </div>
                 {count > 0 && (

--- a/src/features/trash/components/TrashItem.tsx
+++ b/src/features/trash/components/TrashItem.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { motion } from 'framer-motion';
-import { cn } from "@/lib/utils";
 import { MemoCard } from "@/features/memos";
 import { Memo } from "@/types/memo";
 
@@ -14,31 +13,19 @@ export function TrashItem({ memo, index }: TrashItemProps) {
     return (
         <motion.div
             layout
-            initial={{ opacity: 0, y: 20, rotate: -1 }}
-            animate={{ opacity: 1, y: 0, rotate: 0 }}
-            exit={{ opacity: 0, scale: 0.95, filter: "blur(10px)" }}
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.95 }}
             transition={{ 
                 delay: index * 0.05, 
-                duration: 0.8,
+                duration: 0.5,
                 ease: [0.23, 1, 0.32, 1] 
             }}
-            className="group relative"
+            className="group relative mb-6"
         >
-            <div className="absolute -left-16 top-10 text-[8px] text-muted-foreground/30 rotate-[-90deg] hidden lg:block font-mono tracking-[0.4em] pointer-events-none select-none uppercase transition-colors group-hover:text-primary/40">
-                Archive Ref: {memo.id.slice(0, 8)}
-            </div>
-            <div className="absolute -right-12 top-10 text-[8px] text-destructive/20 rotate-[90deg] hidden lg:block font-mono tracking-[0.4em] pointer-events-none select-none uppercase group-hover:text-destructive/40 transition-colors">
-                Abandoned
-            </div>
-            
-            <div className={cn(
-                "transition-all duration-700 ease-out rounded-card",
-                "filter grayscale-[0.3] sepia-[0.2] blur-[0.5px] brightness-[0.95]",
-                "hover:filter-none hover:brightness-100 hover:shadow-xl hover:shadow-primary/5",
-                "border border-transparent hover:border-border/40"
-            )}>
-                <MemoCard memo={memo} />
-            </div>
+             <div className="rounded-card shadow-sm border border-transparent transition-colors hover:border-border/40">
+                 <MemoCard memo={memo} />
+             </div>
         </motion.div>
     );
 }

--- a/src/lib/memos/events.ts
+++ b/src/lib/memos/events.ts
@@ -1,0 +1,35 @@
+import { useEffect } from 'react';
+import { Memo } from '@/types/memo';
+
+export type MemoEventPayload = 
+    | { type: 'create'; memo: Memo }
+    | { type: 'update'; id: string; updates: Partial<Memo> }
+    | { type: 'delete'; id: string };
+
+const MEMO_EVENT_NAME = 'justbb-memo-sync';
+
+/**
+ * 触发全局 Memo 状态同步事件
+ */
+export const dispatchMemoEvent = (payload: MemoEventPayload) => {
+    if (typeof window !== 'undefined') {
+        window.dispatchEvent(new CustomEvent(MEMO_EVENT_NAME, { detail: payload }));
+    }
+};
+
+/**
+ * 监听全局 Memo 状态同步事件（Hook）
+ */
+export const useMemoSync = (callback: (payload: MemoEventPayload) => void) => {
+    useEffect(() => {
+        const handler = (e: Event) => {
+            const detail = (e as CustomEvent<MemoEventPayload>).detail;
+            if (detail) {
+                callback(detail);
+            }
+        };
+        
+        window.addEventListener(MEMO_EVENT_NAME, handler);
+        return () => window.removeEventListener(MEMO_EVENT_NAME, handler);
+    }, [callback]);
+};

--- a/src/lib/memos/schemas.ts
+++ b/src/lib/memos/schemas.ts
@@ -1,12 +1,23 @@
 import { z } from 'zod';
 
+const booleanPreprocessor = (val: unknown) => {
+    if (typeof val === 'string') return val.toLowerCase() === 'true';
+    return Boolean(val);
+};
+
+const optionalBooleanPreprocessor = (val: unknown) => {
+    if (val === undefined || val === null || val === '') return undefined;
+    if (typeof val === 'string') return val.toLowerCase() === 'true';
+    return Boolean(val);
+};
+
 /**
  * 基础 Memo 内容 Schema
  */
 export const memoContentSchema = z.object({
     content: z.string().min(1, '内容不能为空'),
-    is_pinned: z.boolean().default(false),
-    is_private: z.boolean().default(false),
+    is_pinned: z.preprocess(booleanPreprocessor, z.boolean().default(false)),
+    is_private: z.preprocess(booleanPreprocessor, z.boolean().default(false)),
     access_code_hint: z.string().optional().nullable(),
     access_code: z.string().optional().nullable(),
 });
@@ -28,8 +39,8 @@ export const updateMemoContentSchema = memoContentSchema.extend({
  */
 export const updateMemoStateSchema = z.object({
     id: z.string().uuid('无效的 ID'),
-    is_pinned: z.boolean().optional(),
-    is_private: z.boolean().optional(),
+    is_pinned: z.preprocess(optionalBooleanPreprocessor, z.boolean().optional()),
+    is_private: z.preprocess(optionalBooleanPreprocessor, z.boolean().optional()),
     access_code_hint: z.string().optional().nullable(),
     access_code: z.string().optional().nullable(), // 原始口令输入，由 Action 负责哈希
 });
@@ -58,7 +69,7 @@ export const fetchMemosSchema = z.object({
     sort: z.enum(['newest', 'oldest']).optional().default('newest'),
     after_date: z.string().nullable().optional(),
     before_date: z.string().nullable().optional(),
-    excludePinned: z.boolean().optional().default(false),
+    excludePinned: z.preprocess(optionalBooleanPreprocessor, z.boolean().optional().default(false)),
 });
 
 export type CreateMemoInput = z.infer<typeof createMemoSchema>;


### PR DESCRIPTION
本次计划将 `feature/memo-sync-refactor` 分支的所有改动合并到 `dev` 分支。

主要改动：
- 移除了 Memo 编辑器中不再使用的全屏/放大功能。
- 优化了对话框关闭后的焦点自动回滚逻辑。
- 已通过全量构建与类型检查。