### PR TITLE
fix(cli): 修复会话刷新并增加搜索分页

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to `justmemo-cli` will be documented in this file.
 
+## Unreleased
+
+### Added
+
+- `search` 支持 `--page` 分页，可与关键词、标签、编号和 `--limit` 组合使用。
+- 搜索结果会显示置顶标识，帮助信息会根据本地登录状态显示对应命令。
+
+### Fixed
+
+- 已登录用户的访问令牌过期后，需识别身份的命令会自动刷新会话并重试。
+
 ## 0.1.1 (2026-07-11)
 
 ### Fixed

--- a/cli/README.md
+++ b/cli/README.md
@@ -10,12 +10,12 @@ justmemo whoami
 justmemo logout
 justmemo publish 今天的记录 #日记
 justmemo search
-justmemo search 工作 旅行 --tag 旅行
+justmemo search 工作 旅行 --tag 旅行 --page 2
 justmemo show 123
 justmemo show 123 --unlock
 ```
 
-未登录也可以搜索和查看公开 Memo。私密 Memo 只会显示锁定状态和口令提示；使用 `--unlock` 时，口令只在当前命令中使用，不会保存。
+未登录也可以搜索和查看公开 Memo；登录后可查看身份，管理员可发布 Memo。`search` 默认显示第 1 页的 20 条结果，可通过 `--limit`（1-100）和 `--page`（1-10000）调整。私密 Memo 只会显示锁定状态和口令提示；使用 `--unlock` 时，口令只在当前命令中使用，不会保存。
 
 `publish` 不加正文时会打开 `$VISUAL` 或 `$EDITOR`；独立一行的 `.jpg/.jpeg/.png/.gif/.webp` 链接会进入图片字段，其他链接保留在正文中。
 
@@ -45,7 +45,7 @@ npm run cli:pack
 
 ## 当前版本
 
-当前版本为 `0.1.0`。
+当前版本为 `0.1.1`。
 
 ## 发布状态
 

--- a/cli/src/client.test.ts
+++ b/cli/src/client.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const { readSession, writeSession } = vi.hoisted(() => ({
+  readSession: vi.fn(),
+  writeSession: vi.fn(),
+}))
+
+vi.mock("./auth-store.js", () => ({ readSession, writeSession }))
+
+import { publishMemo, searchMemos } from "./client.js"
+
+const oldSession = { access_token: "expired-token", refresh_token: "old-refresh-token" }
+const refreshedSession = { access_token: "fresh-token", refresh_token: "fresh-refresh-token" }
+
+function response(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+describe("CLI API client", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it("在发布时自动刷新过期会话并重试", async () => {
+    readSession
+      .mockResolvedValueOnce(oldSession)
+      .mockResolvedValueOnce(oldSession)
+      .mockResolvedValueOnce(refreshedSession)
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        response({ success: false, data: null, error: "请先执行 justmemo login" }, 401)
+      )
+      .mockResolvedValueOnce(response({ success: true, data: refreshedSession, error: null }))
+      .mockResolvedValueOnce(response({ success: true, data: { memo_number: 43 }, error: null }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    await expect(
+      publishMemo({ content: "测试", images: [], is_private: false, is_pinned: false })
+    ).resolves.toMatchObject({ data: { memo_number: 43 } })
+
+    expect(writeSession).toHaveBeenCalledWith(refreshedSession)
+    expect(new Headers(fetchMock.mock.calls[2][1]?.headers).get("Authorization")).toBe(
+      "Bearer fresh-token"
+    )
+  })
+
+  it("将页码发送给搜索接口", async () => {
+    readSession.mockResolvedValue(null)
+    const fetchMock = vi.fn().mockResolvedValue(response({ success: true, data: [], error: null }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    await searchMemos({ query: "", limit: 20, page: 2, json: false })
+
+    expect(fetchMock.mock.calls[0][0]).toContain("limit=20&page=2")
+  })
+
+  it("搜索前刷新已过期的本地会话", async () => {
+    const expiredSession = {
+      access_token: `header.${Buffer.from(JSON.stringify({ exp: 1 })).toString("base64url")}.signature`,
+      refresh_token: "old-refresh-token",
+    }
+    readSession
+      .mockResolvedValueOnce(expiredSession)
+      .mockResolvedValueOnce(expiredSession)
+      .mockResolvedValueOnce(refreshedSession)
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(response({ success: true, data: refreshedSession, error: null }))
+      .mockResolvedValueOnce(response({ success: true, data: [], error: null }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    await searchMemos({ query: "", limit: 20, page: 1, json: false })
+
+    expect(fetchMock.mock.calls[0][0]).toContain("/api/cli/v1/auth/refresh")
+    expect(new Headers(fetchMock.mock.calls[1][1]?.headers).get("Authorization")).toBe(
+      "Bearer fresh-token"
+    )
+  })
+})

--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -11,38 +11,69 @@ import { readSession, writeSession } from "./auth-store.js"
 
 export const DEFAULT_API_URL = "https://just-memo.vercel.app"
 
+type RequestOptions = {
+  retry?: boolean
+  refreshOnUnauthorized?: boolean
+  refreshExpiredSession?: boolean
+}
+
 function getApiUrl() {
   return (process.env.JUSTMEMO_API_URL || DEFAULT_API_URL).replace(/\/$/, "")
+}
+
+function isAccessTokenExpired(accessToken: string) {
+  const payload = accessToken.split(".")[1]
+  if (!payload) return false
+
+  try {
+    const { exp } = JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as {
+      exp?: unknown
+    }
+    return typeof exp === "number" && exp * 1000 <= Date.now()
+  } catch {
+    return false
+  }
+}
+
+async function refreshSession(session: CliSession) {
+  const refreshed = await request<CliSession>(
+    "/api/cli/v1/auth/refresh",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ refresh_token: session.refresh_token }),
+    },
+    { retry: false }
+  )
+  if (!refreshed.data) throw new Error("登录已失效，请重新登录")
+
+  await writeSession(refreshed.data)
+  return refreshed.data
 }
 
 async function request<T>(
   path: string,
   init: RequestInit = {},
-  retry = true
+  {
+    retry = true,
+    refreshOnUnauthorized = false,
+    refreshExpiredSession = false,
+  }: RequestOptions = {}
 ): Promise<CliResponse<T>> {
-  const session = await readSession()
+  let session = await readSession()
+  if (session && refreshExpiredSession && isAccessTokenExpired(session.access_token)) {
+    session = await refreshSession(session)
+  }
   const headers = new Headers(init.headers)
   headers.set("Accept", "application/json")
   if (session?.access_token) headers.set("Authorization", `Bearer ${session.access_token}`)
 
   const response = await fetch(`${getApiUrl()}${path}`, { ...init, headers })
 
-  const shouldRefresh = path === "/api/cli/v1/auth/me"
-  if (response.status === 401 && retry && shouldRefresh && session?.refresh_token) {
+  if (response.status === 401 && retry && refreshOnUnauthorized && session?.refresh_token) {
     try {
-      const refreshed = await request<CliSession>(
-        "/api/cli/v1/auth/refresh",
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ refresh_token: session.refresh_token }),
-        },
-        false
-      )
-      if (refreshed.data) {
-        await writeSession(refreshed.data)
-        return request<T>(path, init, false)
-      }
+      await refreshSession(session)
+      return request<T>(path, init, { retry: false, refreshOnUnauthorized, refreshExpiredSession })
     } catch {
       // 由下面的统一错误处理返回登录失效提示。
     }
@@ -67,12 +98,27 @@ export function searchMemos(options: SearchOptions) {
   if (options.tag) params.set("tag", options.tag)
   if (options.num) params.set("num", options.num)
   params.set("limit", String(options.limit))
+  params.set("page", String(options.page))
 
-  return request<MemoSummary[]>(`/api/cli/v1/memos?${params.toString()}`)
+  return request<MemoSummary[]>(
+    `/api/cli/v1/memos?${params.toString()}`,
+    {},
+    {
+      refreshOnUnauthorized: true,
+      refreshExpiredSession: true,
+    }
+  )
 }
 
 export function showMemo(memoNumber: string) {
-  return request<MemoSummary>(`/api/cli/v1/memos/${encode(memoNumber)}`)
+  return request<MemoSummary>(
+    `/api/cli/v1/memos/${encode(memoNumber)}`,
+    {},
+    {
+      refreshOnUnauthorized: true,
+      refreshExpiredSession: true,
+    }
+  )
 }
 
 export function unlockMemo(memoNumber: string, code: string) {
@@ -96,7 +142,14 @@ export function pollDeviceAuth(requestId: string, code: string) {
 }
 
 export function getCliCurrentUser() {
-  return request<CliUser>("/api/cli/v1/auth/me")
+  return request<CliUser>(
+    "/api/cli/v1/auth/me",
+    {},
+    {
+      refreshOnUnauthorized: true,
+      refreshExpiredSession: true,
+    }
+  )
 }
 
 export function publishMemo(input: {
@@ -107,9 +160,13 @@ export function publishMemo(input: {
   access_code_hint?: string
   is_pinned: boolean
 }) {
-  return request<MemoSummary>("/api/cli/v1/memos/publish", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(input),
-  })
+  return request<MemoSummary>(
+    "/api/cli/v1/memos/publish",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(input),
+    },
+    { refreshOnUnauthorized: true, refreshExpiredSession: true }
+  )
 }

--- a/cli/src/commands.test.ts
+++ b/cli/src/commands.test.ts
@@ -1,18 +1,27 @@
 import { describe, expect, it } from "vitest"
-import { parseCommand } from "./commands.js"
+import { formatHelp, parseCommand } from "./commands.js"
 
 describe("CLI command parsing", () => {
   it("支持不加引号的多词搜索和过滤参数", () => {
-    expect(parseCommand(["search", "旅行", "上海", "--tag", "生活", "--limit", "50"])).toEqual({
+    expect(
+      parseCommand(["search", "旅行", "上海", "--tag", "生活", "--limit", "50", "--page", "3"])
+    ).toEqual({
       name: "search",
       options: {
         query: "旅行 上海",
         tag: "生活",
         num: undefined,
         limit: 50,
+        page: 3,
         json: false,
       },
     })
+  })
+
+  it("拒绝无效页码", () => {
+    expect(() => parseCommand(["search", "--page", "0"])).toThrow(
+      "--page 必须是 1-10000 之间的整数"
+    )
   })
 
   it("支持按 Memo 编号查看和 JSON 输出", () => {
@@ -26,5 +35,14 @@ describe("CLI command parsing", () => {
     expect(parseCommand(["login"])).toEqual({ name: "login" })
     expect(parseCommand(["logout"])).toEqual({ name: "logout" })
     expect(parseCommand(["whoami"])).toEqual({ name: "whoami" })
+  })
+
+  it("根据登录状态展示对应命令", () => {
+    expect(formatHelp(false)).toContain("无需登录即可浏览公开 Memo")
+    expect(formatHelp(false)).not.toContain("justmemo publish")
+
+    expect(formatHelp(true)).toContain("已登录，可浏览 Memo；管理员可发布")
+    expect(formatHelp(true)).toContain("justmemo publish")
+    expect(formatHelp(true)).not.toContain("justmemo login")
   })
 })

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -54,6 +54,7 @@ export function parseCommand(args: string[]): ParsedCommand {
     let tag: string | undefined
     let num: string | undefined
     let limit = 20
+    let page = 1
     let json = false
 
     for (let index = 0; index < rest.length; index += 1) {
@@ -73,6 +74,13 @@ export function parseCommand(args: string[]): ParsedCommand {
           throw new Error("--limit 必须是 1-100 之间的整数")
         }
         index += 1
+      } else if (value === "--page") {
+        const rawPage = readOption(rest, index, "--page")
+        page = Number(rawPage)
+        if (!Number.isInteger(page) || page < 1 || page > 10000) {
+          throw new Error("--page 必须是 1-10000 之间的整数")
+        }
+        index += 1
       } else if (value.startsWith("--")) {
         throw new Error(`不支持的参数：${value}`)
       } else {
@@ -82,7 +90,7 @@ export function parseCommand(args: string[]): ParsedCommand {
 
     return {
       name: "search",
-      options: { query: query.join(" "), tag, num, limit, json },
+      options: { query: query.join(" "), tag, num, limit, page, json },
     }
   }
 
@@ -103,16 +111,31 @@ export function parseCommand(args: string[]): ParsedCommand {
   throw new Error(`暂不支持的命令：${command}`)
 }
 
-export const HELP_TEXT = `JustMemo CLI
+const BROWSE_COMMANDS = `  justmemo search [关键词...] [--tag 标签] [--num 编号] [--limit 数量] [--page 页码] [--json]
+  justmemo show <编号> [--unlock] [--json]`
 
-用法：
-  justmemo login
-  justmemo logout
+export function formatHelp(isLoggedIn: boolean) {
+  if (isLoggedIn) {
+    return `JustMemo CLI
+
+已登录，可浏览 Memo；管理员可发布：
   justmemo whoami
+  justmemo logout
   justmemo publish [正文...] [--private] [--pin] [--json]
-  justmemo search [关键词...] [--tag 标签] [--num 编号] [--limit 数量] [--json]
-  justmemo show <编号> [--unlock] [--json]
+${BROWSE_COMMANDS}
 
-当前无需登录即可搜索和查看公开 Memo。
 私密 Memo 使用 justmemo show <编号> --unlock 临时输入该 Memo 的口令解锁。
 `
+  }
+
+  return `JustMemo CLI
+
+无需登录即可浏览公开 Memo：
+${BROWSE_COMMANDS}
+
+管理员登录后可发布 Memo：
+  justmemo login
+
+私密 Memo 使用 justmemo show <编号> --unlock 临时输入该 Memo 的口令解锁。
+`
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -2,7 +2,7 @@
 
 import { realpathSync } from "node:fs"
 import { fileURLToPath } from "node:url"
-import { parseCommand, HELP_TEXT } from "./commands.js"
+import { formatHelp, parseCommand } from "./commands.js"
 import {
   getCliCurrentUser,
   pollDeviceAuth,
@@ -15,7 +15,7 @@ import {
 import { formatLogin, formatPublish, formatSearch, formatShow, formatWhoami } from "./output.js"
 import { promptSecret } from "./prompt.js"
 import { promptText } from "./prompt.js"
-import { clearSession, writeSession } from "./auth-store.js"
+import { clearSession, readSession, writeSession } from "./auth-store.js"
 import { editText } from "./editor.js"
 import { preparePublishContent } from "./content.js"
 import { openBrowser } from "./browser.js"
@@ -29,7 +29,7 @@ export async function run(args: string[]) {
     const command = parseCommand(args)
 
     if (command.name === "help") {
-      process.stdout.write(HELP_TEXT)
+      process.stdout.write(formatHelp((await readSession()) !== null))
       return 0
     }
 

--- a/cli/src/output.test.ts
+++ b/cli/src/output.test.ts
@@ -33,6 +33,12 @@ describe("CLI output", () => {
     expect(formatSearch([memo])).toBe("#123  2026-07-11  [旅行] 今天去了上海")
   })
 
+  it("搜索结果标记置顶 Memo", () => {
+    expect(formatSearch([{ ...memo, is_pinned: true }])).toBe(
+      "#123  2026-07-11  📌 [旅行] 今天去了上海"
+    )
+  })
+
   it("完整查看输出图片原始 URL", () => {
     expect(formatShow(memo)).toContain("https://example.com/photo.jpg")
     expect(formatShow(memo)).toContain("图片链接：")

--- a/cli/src/output.ts
+++ b/cli/src/output.ts
@@ -36,7 +36,8 @@ export function formatSearch(memos: MemoSummary[]) {
     .map((memo) => {
       const date = memo.created_at.slice(0, 10)
       const locked = memo.is_locked ? "[私密] " : ""
-      return `#${memo.memo_number}  ${date}  ${locked}${tags(memo)}${snippet(memo.content)}`
+      const pinned = memo.is_pinned ? "📌 " : ""
+      return `#${memo.memo_number}  ${date}  ${pinned}${locked}${tags(memo)}${snippet(memo.content)}`
     })
     .join("\n")
 }

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -34,6 +34,7 @@ export type MemoSummary = {
   tags?: string[] | null
   created_at: string
   is_private?: boolean
+  is_pinned?: boolean
   is_locked?: boolean
   access_code_hint?: string | null
   images?: string[] | null
@@ -44,6 +45,7 @@ export type SearchOptions = {
   tag?: string
   num?: string
   limit: number
+  page: number
   json: boolean
 }
 

--- a/src/app/api/cli/v1/memos/route.test.ts
+++ b/src/app/api/cli/v1/memos/route.test.ts
@@ -33,14 +33,16 @@ describe("GET /api/cli/v1/memos", () => {
     rpc.mockResolvedValueOnce({ data: [], error: null })
 
     await GET(
-      new Request("http://localhost/api/cli/v1/memos?q=旅行%20上海&tag=工作&num=123&limit=50")
+      new Request(
+        "http://localhost/api/cli/v1/memos?q=旅行%20上海&tag=工作&num=123&limit=50&page=3"
+      )
     )
 
     expect(rpc).toHaveBeenCalledWith("search_memos_secure", {
       query_text: "旅行 上海",
       unlocked_ids: [],
       limit_val: 50,
-      offset_val: 0,
+      offset_val: 100,
       filters: { tag: "工作", num: "123" },
       sort_order: "newest",
     })

--- a/src/app/api/cli/v1/memos/route.ts
+++ b/src/app/api/cli/v1/memos/route.ts
@@ -4,6 +4,8 @@ import { getCliClient } from "@/server/services/cli/client"
 
 const DEFAULT_LIMIT = 20
 const MAX_LIMIT = 100
+const DEFAULT_PAGE = 1
+const MAX_PAGE = 10000
 
 function jsonResponse<T>(success: boolean, data: T, error: string | null, status = 200) {
   return NextResponse.json({ success, data, error }, { status })
@@ -17,12 +19,24 @@ function parseLimit(value: string | null) {
   return parsed
 }
 
+function parsePage(value: string | null) {
+  if (value === null || value === "") return DEFAULT_PAGE
+
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > MAX_PAGE) return null
+  return parsed
+}
+
 export async function GET(request: Request) {
   const url = new URL(request.url)
   const limit = parseLimit(url.searchParams.get("limit"))
+  const page = parsePage(url.searchParams.get("page"))
 
   if (limit === null) {
     return jsonResponse(false, null, `limit 必须是 1-${MAX_LIMIT} 之间的整数`, 400)
+  }
+  if (page === null) {
+    return jsonResponse(false, null, `page 必须是 1-${MAX_PAGE} 之间的整数`, 400)
   }
 
   const queryText = url.searchParams.get("q") || ""
@@ -37,7 +51,7 @@ export async function GET(request: Request) {
     query_text: queryText,
     unlocked_ids: [],
     limit_val: limit,
-    offset_val: 0,
+    offset_val: (page - 1) * limit,
     filters: filters as unknown as Json,
     sort_order: "newest",
   })


### PR DESCRIPTION
## 修改内容

- access token 过期时，`search`、`show`、`whoami` 和 `publish` 自动刷新会话并重试，保留作者的私密 Memo 可见性。
- `justmemo search` 增加 `--page`，与 `--limit` 组合转换为后端 offset。
- 根据登录状态展示 help，搜索结果展示置顶标识，并明确仅管理员可发布。
- 更新 CLI README 与 CHANGELOG。

## 验证

- `npm test`
- `npm run check:cli`
- `npm run build`
- 已验证 GPG 签名提交。